### PR TITLE
Fix post-login sometimes getting lost when using mosh.

### DIFF
--- a/src/org/woltage/irssiconnectbot/transport/Mosh.java
+++ b/src/org/woltage/irssiconnectbot/transport/Mosh.java
@@ -149,6 +149,11 @@ public class Mosh extends SSH implements ConnectionMonitor, InteractiveCallback,
 
 			sessionOpen = true;
 
+			// Give some time for mosh to init, otherwise we might loose the post-login automation.
+			try {
+				Thread.sleep(500);
+			} catch (InterruptedException e) {}
+
 			bridge.onConnected();
 		} catch (IOException e1) {
 			Log.e(TAG, "Problem while trying to create PTY in finishConnection()", e1);

--- a/src/org/woltage/irssiconnectbot/transport/Mosh.java
+++ b/src/org/woltage/irssiconnectbot/transport/Mosh.java
@@ -24,7 +24,6 @@ import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.net.InetAddress;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -44,7 +43,6 @@ import com.trilead.ssh2.ChannelCondition;
 import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.ConnectionMonitor;
 import com.trilead.ssh2.InteractiveCallback;
-import com.trilead.ssh2.Session;
 import com.trilead.ssh2.ServerHostKeyVerifier;
 
 import com.google.ase.Exec;


### PR DESCRIPTION
I added a simple 500ms sleep before calling bridge.onConnected(). Without this, my post-login automation commands were lost in the cyberspace most of the time when using mosh.

In the master branch of my fork, I've got some more commits that might be of interest. They are not related to mosh functionality, though. :)
